### PR TITLE
update links to point to wasmfx repos

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -47,12 +47,12 @@
             <ul>
               <li>WasmFX <a href="/specs/core">typed continuations core extensions document</a>.</li>
               <li>WasmFX <a href="/specs/explainer">typed continuations design explainer document</a>.</li>
-              <li><a href="https://github.com/effect-handlers/wasm-spec">Wasm
+              <li><a href="https://github.com/wasmfx/specfx">Wasm
               reference interpreter</a> extended with the typed
               continuation proposal.</li>
               <li>WasmFX typed continuations implementation
-              in <a href="https://github.com/effect-handlers/wasm-tools">wasm-tools</a>
-              and <a href="https://github.com/effect-handlers/wasmtime">wasmtime</a>.</li>
+              in <a href="https://github.com/wasmfx/wasmfx-tools">wasm-tools</a>
+              and <a href="https://github.com/wasmfx/wasmfxtime">wasmtime</a>.</li>
               <li>Follow the <a href="https://twitter.com/wasmfx">WasmFX Twitter account</a> to stay up-to-date.</li>
               <li>The <a href="https://github.com/WebAssembly/stack-switching">WebAssembly Stack Switching subgroup</a>.</li>
               <li><a href="https://effect-handlers.org">The effect handler oriented programming project website</a>.</li>
@@ -80,10 +80,10 @@
             <p>Please contribute your feedback or issues in the following forums:</p>
             <ul>
               <li>High level design feedback: <a href="https://github.com/WebAssembly/stack-switching">WebAssembly/stack-switching</a></li>
-              <li>Specification bugs / suggestions: <a href="https://github.com/effect-handlers/wasm-spec">effect-handlers/wasm-spec</a></li>
-              <li>Test suite / reference interpreter issues: <a href="https://github.com/effect-handlers/wasm-spec">effect-handlers/wasm-spec</a></li>
-              <li>Wasm-tools issues: <a href="https://github.com/effect-handlers/wasm-tools">effect-handlers/wasm-tools</a></li>
-              <li>Wasmtime bugs: <a href="https://github.com/effect-handlers/wasmtime">effect-handlers/wasmtime</a></li>
+              <li>Specification bugs / suggestions: <a href="https://github.com/wasmfx/specfx">wasmfx/specfx</a></li>
+              <li>Test suite / reference interpreter issues: <a href="https://github.com/wasmfx/specfx">wasmfx/specfx</a></li>
+              <li>Wasm-tools issues: <a href="https://github.com/wasmfx/wasmfx-tools">wasmfx/wasmfx-tools</a></li>
+              <li>Wasmtime bugs: <a href="https://github.com/wasmfx/wasmfxtime">wasmfx/wasmfxtime</a></li>
               <li>Website bugs: <a href="https://github.com/wasmfx/wasmfx.github.io">WasmFX/wasmfx.github.io</a></li>
             </ul>
 
@@ -115,9 +115,9 @@
               </p>
               <ul>
                 <li>Reference interpreter
-                repository: <a href="https://github.com/effect-handlers/wasm-spec">effect-handlers/wasm-spec</a>.</li>
+                repository: <a href="https://github.com/wasmfx/specfx">wasmfx/specfx</a>.</li>
                 <li>The explainer document for typed
-                continuations: <a href="https://github.com/effect-handlers/wasm-spec/blob/master/proposals/continuations/Explainer.md">effect-handlers/wasm-spec</a>.</li>
+                continuations: <a href="https://github.com/wasmfx/specfx/blob/master/proposals/continuations/Explainer.md">wasmfx/specfx</a>.</li>
               </ul>
 
             <h3 id="wasm-tools-and-wasmtime-implementations">Wasm-tools and Wasmtime implementations</h2>
@@ -144,8 +144,8 @@
 
             <p>Relevant resources:</p>
             <ul>
-              <li>Wasm-tools repository: <a href="https://github.com/effect-handlers/wasm-tools">effect-handlers/wasm-tools</a>.</li>
-              <li>Wasmtime repository: <a href="https://github.com/effect-handlers/wasmtime">effect-handlers/wasmtime</a>.</li>
+              <li>Wasm-tools repository: <a href="https://github.com/wasmfx/wasmfx-tools">wasmfx/wasmfx-tools</a>.</li>
+              <li>Wasmtime repository: <a href="https://github.com/wasmfx/wasmfxtime">wasmfx/wasmfxtime</a>.</li>
               <li>Typed function references specification: <a href="https://github.com/WebAssembly/function-references">WebAssembly/function-references</a>.</li>
               <li>Exception handling specification: <a href="https://github.com/WebAssembly/exception-handling">WebAssembly/exception-handling</a>.</li>
               <li>Tail call specification: <a href="https://github.com/WebAssembly/tail-call">WebAssembly/tail-call</a>.</li>

--- a/specs/explainer/index.html
+++ b/specs/explainer/index.html
@@ -430,7 +430,7 @@ same continuation object will result in a trap.
 
 <p>
 (The full code for this example
-is <a href="https://github.com/effect-handlers/wasm-spec/tree/master/proposals/continuations/examples/static-lwt.wast">here</a>.)
+is <a href="https://github.com/wasmfx/specfx/tree/master/proposals/continuations/examples/static-lwt.wast">here</a>.)
 </p>
 
 <p>
@@ -620,7 +620,7 @@ reference into a corresponding continuation reference.
 
 <p>
 (The full code for this example
-is <a href="https://github.com/effect-handlers/wasm-spec/tree/master/proposals/continuations/examples/lwt.wast">here</a>.)
+is <a href="https://github.com/wasmfx/specfx/tree/master/proposals/continuations/examples/lwt.wast">here</a>.)
 </p>
 
 <p>
@@ -1052,7 +1052,7 @@ The output is as follows, demonstrating the various different scheduling behavio
 
 <p>
 (The full code for this example
-is <a href="https://github.com/effect-handlers/wasm-spec/tree/master/proposals/continuations/examples/control-lwt.wast">here</a>.)
+is <a href="https://github.com/wasmfx/specfx/tree/master/proposals/continuations/examples/control-lwt.wast">here</a>.)
 </p>
 
 <p>


### PR DESCRIPTION
This updates all the stale links pointing to repos in the effect handler organisation to the corresponding ones in the wasmfx organisation